### PR TITLE
Исправить отображение картинки на github pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 		<div id="modal-overlay"></div>
 		<div id="image-modal">
 			<span id="close-modal">&times;</span>
-			<img src="/img/Image.jpg" alt="Popup Image" />
+			<img src="img/image.jpg" alt="Popup Image" />
 		</div>
 
 		<script src="script.js"></script>


### PR DESCRIPTION
Fix image display on GitHub Pages by correcting image path case and making it relative.

GitHub Pages, running on Linux servers, is case-sensitive for file paths. Additionally, absolute paths with a leading slash can cause incorrect resolution on GitHub Pages, making relative paths more reliable.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-7c1a1f94-a8e9-4c22-9eed-29a9bd8fc216) · [Cursor](https://cursor.com/background-agent?bcId=bc-7c1a1f94-a8e9-4c22-9eed-29a9bd8fc216)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)